### PR TITLE
fixed home page no show duplicate queue

### DIFF
--- a/app/views/queue_walls/index.html.erb
+++ b/app/views/queue_walls/index.html.erb
@@ -23,7 +23,7 @@
           </div>
 
           <div class="queue-status d-flex justify-content-between">
-            <% @queues.by_range(q.id).each do |q| %>
+            <% @queues.by_range(q.id).by_level_and_latest.each do |q| %>
               <div class="level-queue d-flex flex-column px-3 align-items-center">
                 <small><%= "#{q.level}"%></small>
                 <small><%= "#{q.queue_length} pax"%></small>


### PR DESCRIPTION
## Why
Queue Wall to not show duplicate and only the latest update for each level.
## What
Queue walls status at home page to not show duplicate.
​
### Screenshot
​![image](https://user-images.githubusercontent.com/76784318/145016211-3e93e4a1-3385-4c71-a0bc-6632db27f5cb.png)