### PR TITLE
fixed queuewall page for visitors

### DIFF
--- a/app/views/queue_walls/_queue_wall.html.erb
+++ b/app/views/queue_walls/_queue_wall.html.erb
@@ -4,7 +4,7 @@
     <h2><%= queue_wall.level %>:</h2>
     <h2><%= queue_wall.queue_length %> pax in queue</h2>
     <div class="votes d-flex">
-      <% if current_user.voted_up_on? queue_wall %>
+      <% if current_user.present? && current_user.voted_up_on?(queue_wall) %>
         <%# <h2><i class="fas fa-thumbs-up p-2"></i></h2> %>
         <%= link_to "", toggle_vote_queue_wall_path(queue_wall),
                           class: "fas fa-thumbs-up p-2",
@@ -28,7 +28,7 @@
                 } %>
       <% end %>
       <h2 class="align-self-center" data-vote-button-target="upcounter" value="<%= queue_wall.get_likes.size %>"><%= queue_wall.get_likes.size %></h2>
-      <% if current_user.voted_down_on? queue_wall %>
+      <% if current_user.present? && current_user.voted_down_on?(queue_wall) %>
         <%# <h2><i class="fas fa-thumbs-up p-2"></i></h2> %>
         <%= link_to "", toggle_vote_queue_wall_path(queue_wall),
                           class: "fas fa-thumbs-down p-2",


### PR DESCRIPTION
## Why
So visitors can see queuewall page without having an error.
​
## What​
​Added current_user.present? in _queuewall partial html
​
### Screenshot
​![image](https://user-images.githubusercontent.com/76784318/145124525-4a771472-3b86-4277-8834-648ef15c99e9.png)
