### PR TITLE
added pre-animation to splash and moved tagline so viewable in saferi…

### DIFF
--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -7,7 +7,15 @@
   width: 100%;
   transition: 400ms;
 }
-
+@keyframes slideUp {
+  0% {
+    position: fixed;
+    top: 120%;
+  }
+  100% {
+    top: 60%;
+  }
+}
 
 p.tag-line {
   font-size: 1rem;
@@ -17,6 +25,7 @@ p.tag-line {
   left: 50%;
   color: white;
   transition: 300ms ease-out;
+  animation: slideUp 300ms ease-out 0;
   transform: translate(-50%, -50%);
 }
 
@@ -54,8 +63,20 @@ h2.logo-text{
   left: 50%;
   color: white;
   transition: 300ms ease-out;
+  animation: zoomIn 500ms ease-out 0;
   transform: translate(-50%, -50%);
 }
+
+@keyframes zoomIn {
+  0% {
+    font-size: 1rem;
+  }
+  100% {
+    font-size: 10rem;
+  }
+}
+
+
 // ANIMATION STEP 1
 .navbar-lewagon.navbar-animate-one{
   .golf-logo{
@@ -88,7 +109,7 @@ h2.logo-text{
   min-height: 100vh;
 
   .nav-icon {
-    top: 30%;
+    top: 25%;
     opacity: 1;
     transform: translate(-50%, -50%);
   }

--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -22,10 +22,10 @@ p.tag-line {
   position: fixed;
   top: 0;
   opacity:0;
-  left: 50%;
+  left: 35%;
   color: white;
   transition: 300ms ease-out;
-  animation: slideUp 300ms ease-out 0;
+  // animation: slideUp 300ms ease-out 0;
   transform: translate(-50%, -50%);
 }
 
@@ -63,7 +63,7 @@ h2.logo-text{
   left: 50%;
   color: white;
   transition: 300ms ease-out;
-  animation: zoomIn 500ms ease-out 0;
+  // animation: zoomIn 500ms ease-out 0;
   transform: translate(-50%, -50%);
 }
 

--- a/app/javascript/controllers/home_animation_controller.js
+++ b/app/javascript/controllers/home_animation_controller.js
@@ -27,7 +27,7 @@ export default class extends Controller {
           }, 300);
         }, 300);
       }, 300);
-    }, 1500);
+    }, 1800);
     console.log("Home Animation Controller Connected!");
 
   }

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -5,6 +5,7 @@
         <div class="golf-logo">Golf</div>
         <div class="queue-logo">Queue</div>
       </h2>
+      <p class="tag-line">Got long queue ah?</p>
     <% end %>
 
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
@@ -47,7 +48,7 @@
    </div>
 
   <div class="nav-icon" data-home-animation-target="icon"><i class="fas fa-golf-ball"></i></div>
-  <p class="tag-line">Got long queue ah?</p>
+
 
   </div>
 </div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -5,7 +5,7 @@
         <div class="golf-logo">Golf</div>
         <div class="queue-logo">Queue</div>
       </h2>
-      <p class="tag-line">Got long queue ah?</p>
+      <p class="tag-line animate__animated animate__rubberBand">Got long queue ah?</p>
     <% end %>
 
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
@@ -47,7 +47,7 @@
     </ul>
    </div>
 
-  <div class="nav-icon" data-home-animation-target="icon"><i class="fas fa-golf-ball"></i></div>
+  <div class="nav-icon animate__animated animate__zoomInDown" data-home-animation-target="icon"><i class="fas fa-golf-ball"></i></div>
 
 
   </div>


### PR DESCRIPTION
## Why
So tagline doesn not clash with Golfqueue brandname.
Preanimation for more animation before splash animation starts.
​
## What
​Added pre-animation of icon and tagline before splash animation.
Shifted tagline position down a bit using top 60%
​
### Screenshot​
![tkX4FcgIdH](https://user-images.githubusercontent.com/76784318/145225453-7123c8d2-23e3-4d56-9251-9f5f540a8ebf.gif)


