### PR TITLE
Queue wall show pic, auth before playwall acess

### DIFF
--- a/app/controllers/playwall_posts_controller.rb
+++ b/app/controllers/playwall_posts_controller.rb
@@ -1,5 +1,5 @@
 class PlaywallPostsController < ApplicationController
-  before_action :authenticate_user!, only: :toggle_favorite
+  before_action :authenticate_user!
 
   def index
     @playwall = PlaywallPost.all

--- a/app/views/queue_walls/_queue_wall.html.erb
+++ b/app/views/queue_walls/_queue_wall.html.erb
@@ -1,5 +1,9 @@
 <div class="card-trip" data-controller="vote-button">
-  <img src="https://source.unsplash.com/1920x1080/?golf" />
+
+  <% if queue_wall.photo.attached? %>
+  <%= cl_image_tag queue_wall.photo.key, crop: :fill %>
+  <% end %>
+
   <div class="card-trip-infos">
     <h2><%= queue_wall.level %>:</h2>
     <h2><%= queue_wall.queue_length %> pax in queue</h2>
@@ -77,6 +81,6 @@
       <p class="text-muted"><i class="far fa-clock"></i>posted <%= time_ago_in_words(queue_wall.created_at).gsub('about ', '') %> ago</p>
     <% end %>
 
-    <%= link_to "Update #{queue_wall.level}", new_golf_range_queue_wall_path(@golfrange, level: queue_wall.level)  %>
+    <%= link_to "Update #{queue_wall.level}", new_golf_range_queue_wall_path(@golfrange, level: queue_wall.level), class: "btn btn-primary" %>
   </div>
 </div>

--- a/app/views/queue_walls/new.html.erb
+++ b/app/views/queue_walls/new.html.erb
@@ -12,7 +12,7 @@
                     } %>
       <%= f.input :queue_length, input_html: { 'data-queue-update-target': 'output' }, label: false  %>
       <%= f.input :photo, as: :file %>
-      <%= f.button :submit %>
+      <%= f.button :submit, class: "btn btn-primary" %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
## Why
​
This pull request is needed because:
​
To show actual photo on queue wall
​Require authentication before accessing playwall
​
## What
​
This pull request introduces the following:
​
 * Queue wall to show cloudinary image
 * Change playwall controller to require authentication before access
​
### Screenshot
​
<img width="429" alt="image" src="https://user-images.githubusercontent.com/89674340/145326590-7d83deb6-e0af-45e6-9910-d5e40d1361d1.png">


