### PR TITLE
log in is required before updating queue

### DIFF
--- a/app/controllers/queue_walls_controller.rb
+++ b/app/controllers/queue_walls_controller.rb
@@ -3,9 +3,8 @@ require 'open-uri'
 
 class QueueWallsController < ApplicationController
   skip_before_action :authenticate_user!, only: %i[index filter]
-  before_action :authenticate_user!, only: :toggle_votes
+  before_action :authenticate_user!
   before_action :find_golfrange, only: %i[new create]
-
 
   def index
     @queues = QueueWall.all


### PR DESCRIPTION
## Why
​
This pull request is needed because:

Login is required before user can update queue wall

​
## What
​
This pull request introduces the following:
​
 * Updated devise before authentication

​
### Screenshot
​
![Kapture 2021-12-10 at 09 32 29](https://user-images.githubusercontent.com/89674340/145502308-ecf924cb-56ac-4a55-a637-551044262cbd.gif)

