### PR TITLE
center username to be aligned with avatar, caption text standardized

### DIFF
--- a/app/views/playwall_posts/_playwall_post.html.erb
+++ b/app/views/playwall_posts/_playwall_post.html.erb
@@ -1,6 +1,6 @@
 <div class="card-trip">
       <div class="card-trip-infos">
-        <h2 class="pt-2">
+        <h2 class="pt-2 d-flex align-items-center">
           <% if playwall_post.user.photo.attached? %>
             <%= cl_image_tag playwall_post.user.photo.key, width: 40, height: 40, crop: :thumb, gravity: :face, class: "avatar" %>
           <% elsif playwall_post.user.image.present? %>
@@ -8,7 +8,7 @@
           <% else %>
             <i class="far fa-user-circle avatar fa-2x text-black"></i>
           <% end %>
-        @<%= playwall_post.user.username %></h2>
+          @<%= playwall_post.user.username %></h2>
         <p class="text-muted"><%= playwall_post.golf_range.name %></p>
       </div>
         <% if playwall_post.photos.attached? %>

--- a/app/views/playwall_posts/_playwall_posts.html.erb
+++ b/app/views/playwall_posts/_playwall_posts.html.erb
@@ -2,7 +2,7 @@
 <% playwall_posts.each do |playwall_post| %>
     <div class="card-trip">
           <div class="card-trip-infos">
-            <h2 class="pt-2">
+            <h2 class="pt-2 d-flex align-items-center">
           <% if playwall_post.user.photo.attached? %>
             <%= cl_image_tag playwall_post.user.photo.key, width: 40, height: 40, crop: :thumb, gravity: :face, class: "avatar" %>
           <% elsif playwall_post.user.image.present? %>
@@ -10,7 +10,7 @@
           <% else %>
             <i class="far fa-user-circle avatar fa-2x text-black"></i>
           <% end %>
-        @<%= playwall_post.user.username %></h2>
+          @<%= playwall_post.user.username %></h2>
             <p class="text-muted"><%= playwall_post.golf_range.name %></p>
           </div>
         <% if playwall_post.photos.attached? %>
@@ -76,7 +76,7 @@
       <%=link_to "", new_playwall_post_play_wall_report_path(playwall_post), class: "fas fa-exclamation-circle align-left"%>
     </div>
     <div class="card-trip-infos pt-3">
-      <p><%= playwall_post.caption %></p>
+      <h6><%= playwall_post.caption %></h6>
     </div>
       <div class="card-trip-infos pt-3">
 


### PR DESCRIPTION
## Why
​Standardized playwall posts text and username alignment.
​
## What
Centered username with avatar.
standardized text for captions of playwall posts
​
### Screenshot
​
![image](https://user-images.githubusercontent.com/76784318/145605033-255913e5-fcd2-4de3-b79a-a085e763d0a9.png)
