### PR TITLE
better visibility on details and queue situation

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -1,7 +1,7 @@
 .card-category {
   background-size: cover;
   background-position: center;
-  height: 110px;
+  height: 100px;
   // display: flex;
   // justify-content: space-between;
   // align-items: space-between;

--- a/app/controllers/queue_walls_controller.rb
+++ b/app/controllers/queue_walls_controller.rb
@@ -7,6 +7,18 @@ class QueueWallsController < ApplicationController
   before_action :find_golfrange, only: %i[new create]
 
   def index
+    q_num = (0..30).to_a
+    @queue_count = {}
+    q_num.map do |n|
+      case n
+      when 0..3
+        @queue_count[n] = 1
+      when 4..8
+        @queue_count[n] = 2
+      when 9..30
+        @queue_count[n] = 3
+      end
+    end
     @queues = QueueWall.all
     @ranges = GolfRange.all
     @weather = weather_status(@ranges)

--- a/app/models/queue_wall.rb
+++ b/app/models/queue_wall.rb
@@ -12,4 +12,6 @@ class QueueWall < ApplicationRecord
   end
 
   acts_as_votable
+
+  validates :queue_length, inclusion: { in: (0..30) }
 end

--- a/app/views/queue_walls/index.html.erb
+++ b/app/views/queue_walls/index.html.erb
@@ -26,7 +26,12 @@
               <% @queues.by_range(q.id).by_level_and_latest.each do |q| %>
                 <div class="level-queue d-flex flex-column px-3 align-items-center">
                   <small><%= "#{q.level}"%></small>
-                  <p class="m-0"><%= "#{q.queue_length}"%></p>
+                  <p class="m-0">
+                    <% (@queue_count[q.queue_length]).times do %>
+                    <i class="fas fa-male"></i>
+                    <% end %>
+                  </p>
+                  <!--<p class="m-0"><%= "#{q.queue_length}"%></p>-->
                 </div>
               <% end %>
             </div>


### PR DESCRIPTION
## Why
User easier understanding on queuelength context with icons instead of numbers.

## What
Change queue length to show icons instead of numbers.
​
### Screenshot
​![image](https://user-images.githubusercontent.com/76784318/145766974-54ad2b27-5caa-46fb-ad95-16af6ac13f9d.png)