### PR TITLE
truncate golf range name on queuewall navbar'

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -9,7 +9,7 @@
           </h2>
         <% end %>
         <div class="golfrange-text"> <!--style="font-size:2rem; color: white;"-->
-          <h2 style="color: white;"><%= @golfrange.name %></h2>
+          <h2 style="color: white;"><%= @golfrange.name.first(12) %></h2>
         </div>
       <% else %>
         <%= link_to root_path, class: "navbar-brand" do %>


### PR DESCRIPTION
## Why
So navbar is standard for all golf range names.
​
## What
Fixed punggol par range navbar title too long.

### Screenshot
![YY2zoe5Fnz](https://user-images.githubusercontent.com/76784318/145775089-7a04514d-a7ea-4e77-941a-a7f45f8e6cc9.gif)
​