### PR TITLE
Remove location button

### DIFF
--- a/app/views/queue_walls/index.html.erb
+++ b/app/views/queue_walls/index.html.erb
@@ -8,7 +8,7 @@
             <h4><%= q.name %></h4>
           </div>
           <div class="weather-status m-0">
-            <h4 class="px-1"><%= image_tag "http://openweathermap.org/img/wn/#{@weather[index]}.png" %></h4>
+            <h4 class="px-1"><%= image_tag "https://openweathermap.org/img/wn/#{@weather[index]}.png" %></h4>
           </div>
 
         </div>
@@ -24,7 +24,7 @@
             <p class="px-3"; style="margin: 0;">Pax in queue:</p>
             <div class="queue-status d-flex justify-content-between">
               <% @queues.by_range(q.id).by_level_and_latest.each do |q| %>
-                <div class="level-queue d-flex flex-column px-3 align-items-center">
+                <div class="level-queue d-flex flex-column px-1 align-items-center">
                   <small><%= "#{q.level}"%></small>
                   <p class="m-0">
                     <% (@queue_count[q.queue_length]).times do %>

--- a/app/views/queue_walls/index.html.erb
+++ b/app/views/queue_walls/index.html.erb
@@ -46,6 +46,3 @@
   <%= javascript_include_tag "currentcoords.js" %>
 <% end %>
 --->
-<button id="location" data-controller="location" data-action="click->location#allow" class="btn btn-outline-primary bg-light" style="position: fixed; bottom: 1rem; right: 1rem; border-radius: 50%;">
-  <i class="fas fa-location-arrow"></i>
-</button>


### PR DESCRIPTION
## Why
ios safari allow location services.
queue icons viewable on smaller width phones.
Removed Allow location
​
## What
1. Changed weather api call to https to allow location services in ios.
2. reduce padding on queue situation icons.
3.  removed allow location button.
​
### Screenshot
![image](https://user-images.githubusercontent.com/76784318/145795545-21e0d025-3cdd-43de-8293-f14286c8b039.png)
