### PR TITLE
added legend queuewall situation icons at home page

### DIFF
--- a/app/views/queue_walls/index.html.erb
+++ b/app/views/queue_walls/index.html.erb
@@ -40,6 +40,35 @@
       </div>
     <% end %>
   <% end %>
+  <div class="card-category d-flex justify-content-between" style="background-image: linear-gradient(rgba(0,0,0,0.8), rgba(0,0,0,0.8))">
+    <h4>Legend:</h4>
+    <div class="queue-pax-info">
+      <div class="m-0 d-flex justify-content-around align-items-center">
+        <p class="px-2 m-0">
+          <% 1.times do %>
+          <i class="fas fa-male"></i>
+          <% end %>
+        </p>
+        <span>0 - 3 people</span>
+      </div>
+      <div class="m-0 d-flex justify-content-around align-items-center">
+        <p class="px-2 m-0">
+          <% 2.times do %>
+          <i class="fas fa-male"></i>
+          <% end %>
+        </p>
+        <span>4 - 8 people</span>
+      </div>
+      <div class="m-0 d-flex justify-content-around align-items-center">
+        <p class="px-2 m-0">
+          <% 3.times do %>
+          <i class="fas fa-male"></i>
+          <% end %>
+        </p>
+        <span>>8 people</span>
+      </div>
+    </div>
+  </div>
 </div>
 <!---
 <% unless @lat_lng %>


### PR DESCRIPTION
## Why
So users have context about the icons used to represent the  queue situation.
​
## What
Added legend on home page regarding queuewall situation icons.
​
### Screenshot
​![image](https://user-images.githubusercontent.com/76784318/145835561-4c7c4c0b-67f1-4613-91d7-3999288ce7cd.png)