### PR TITLE
notification remove badges when read after 2.5s

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,12 +1,15 @@
 class NotificationsController < ApplicationController
 
   def index
-    @notifications = current_user.notifications.sorted_unread.first(15)
+    if current_user.notifications.unread.count.zero?
+      @notifications = current_user.notifications.newest_first.first(15)
+    else
+      @notifications = current_user.notifications.sorted_unread.first(15)
+    end
   end
 
   def mark_read
-    @notifications = current_user.notifications.sorted_unread.first(15)
-
+    index
     @notifications.each do |n|
       n.mark_as_read!
     end

--- a/app/javascript/controllers/notification_read_controller.js
+++ b/app/javascript/controllers/notification_read_controller.js
@@ -22,9 +22,15 @@ export default class extends Controller {
         .then(response => response.json())
         .then((data) => {
           console.log(data);
-          this.notificationTarget.classList.remove('unread');
+          document.querySelectorAll(".unread").forEach((b) =>{
+            b.classList.remove("unread");
+          })
+          document.querySelectorAll(".badges").forEach((b) => {
+            b.classList.add("d-none");
+          })
+          // this.notificationTarget.classList.remove('unread');
         });
-    }, 4000);
+    }, 2500);
   }
 
   disconnect() {


### PR DESCRIPTION
## Why
1. Notifications fixed to be sorted by latest even when there is no unread notifications.
2. Badges are removed after notifications are read after 2.5s

## What
​1. fixed notifications to sort by latest only.
2. use js to remove badges in notifications page.

​
### Screenshot
![hTofvdEMlG](https://user-images.githubusercontent.com/76784318/146152981-751c268a-4bb9-4fa9-8017-a95a2455aabc.gif)

