### PR TITLE
bootstrap info color change back to yellow

### DIFF
--- a/app/assets/stylesheets/config/_bootstrap_variables.scss
+++ b/app/assets/stylesheets/config/_bootstrap_variables.scss
@@ -13,7 +13,7 @@ $font-size-base: 1rem;
 $body-color: $gray;
 $primary:    $blue;
 $success:    $green;
-$info:       $gray;
+$info:       $yellow;
 $danger:     $red;
 $warning:    $orange;
 


### PR DESCRIPTION
## Why
So flash messages appear yellow instead of gray.
​
## What
Bootstrap info color revert back to yellow
​
### Screenshot
![image](https://user-images.githubusercontent.com/76784318/146299939-9c999ca1-0034-441e-8271-fdd4ca9aae55.png)
