### PR TITLE
playwall avatar UI fix, manifest remove orientation portrait

### DIFF
--- a/app/assets/config/manifest.json.erb
+++ b/app/assets/config/manifest.json.erb
@@ -2,7 +2,6 @@
   "background_color": "green",
   "description": "Golf Queue are made by golfers for golfers.",
   "display": "fullscreen",
-  "orientation": "portrait",
   "name": "Golf Queue",
   "icons": [
     <% files = Dir.entries(Rails.root.join("app/assets/images/icons/")).select {|f| !File.directory? f

--- a/app/views/playwall_posts/_playwall_post.html.erb
+++ b/app/views/playwall_posts/_playwall_post.html.erb
@@ -8,7 +8,7 @@
           <% else %>
             <i class="far fa-user-circle avatar fa-2x text-black"></i>
           <% end %>
-          @<%= playwall_post.user.username %></h2>
+          <b class="pl-2">@<%= playwall_post.user.username %></b></h2>
         <p class="text-muted"><%= playwall_post.golf_range.name %></p>
       </div>
         <% if playwall_post.photos.attached? %>
@@ -113,6 +113,6 @@
     <% end %>
   </div>
   <div class="card-trip-infos pt-3">
-    <p class="text-muted"><i class="far fa-clock"></i> posted <%= time_ago_in_words(playwall_post.created_at).gsub('about ','') %> ago</p>
+    <p class="text-muted"><i class="far fa-clock pr-12"></i> posted <%= time_ago_in_words(playwall_post.created_at).gsub('about ','') %> ago</p>
   </div>
 </div>

--- a/app/views/playwall_posts/_playwall_posts.html.erb
+++ b/app/views/playwall_posts/_playwall_posts.html.erb
@@ -10,7 +10,7 @@
           <% else %>
             <i class="far fa-user-circle avatar fa-2x text-black"></i>
           <% end %>
-          @<%= playwall_post.user.username %></h2>
+          <b class="pl-2">@<%= playwall_post.user.username %></b></h2>
             <p class="text-muted"><%= playwall_post.golf_range.name %></p>
           </div>
         <% if playwall_post.photos.attached? %>
@@ -118,7 +118,7 @@
     <% end %>
   </div>
     <div class="card-trip-infos pt-3">
-      <p class="text-muted"><i class="far fa-clock"></i>posted <%= time_ago_in_words(playwall_post.created_at).gsub('about ','') %> ago</p>
+      <p class="text-muted"><i class="far fa-clock pr-1"></i>posted <%= time_ago_in_words(playwall_post.created_at).gsub('about ','') %> ago</p>
     </div>
   </div>
 


### PR DESCRIPTION
## Why
1. Playwall post UI fix
2. to debug portrait photo uploaded converted to landscape mode.
​
## What
1. playwall post avatar UI fix.
2. manifest json remove orientation portrait.
​
### Screenshot
​![image](https://user-images.githubusercontent.com/76784318/146305764-24558b8b-58d0-41f3-81ca-4bf1cfad9b93.png)