### PR TITLE
set timer to be 1000 instead of 200

### DIFF
--- a/app/javascript/controllers/infinite_scroll_controller.js
+++ b/app/javascript/controllers/infinite_scroll_controller.js
@@ -60,7 +60,7 @@ export default class extends Controller {
         this.loadMore();
         setTimeout(() => {
           this.carousel();
-        }, 200);
+        }, 1000);
       }
     })
   }


### PR DESCRIPTION
## Why
so carousel works on first render.
​
## What
Change timeout to 1000 instead 200 so mobile users carousell actually works.
​
### Screenshot
​![image](https://user-images.githubusercontent.com/76784318/148036005-0d047527-281a-427b-8984-621986dd0d73.png)