### PR TITLE
gliderjs changed form using settimeout to scroll instead

### DIFF
--- a/app/javascript/controllers/infinite_scroll_controller.js
+++ b/app/javascript/controllers/infinite_scroll_controller.js
@@ -58,9 +58,10 @@ export default class extends Controller {
       if (entry.isIntersecting) {
         console.log('hitting the intersection');
         this.loadMore();
-        setTimeout(() => {
+        document.addEventListener("scroll", () => {
+          console.log("scroll");
           this.carousel();
-        }, 1000);
+        })
       }
     })
   }


### PR DESCRIPTION
## Why
Set time out doesnt work when images take too long to load.
​
## What
Change to use scroll instead of time out
​
### Screenshot
​![image](https://user-images.githubusercontent.com/76784318/148037769-d9accc18-887b-406f-96b6-4b412cbd9f9e.png)